### PR TITLE
Return to classic zone entry messages

### DIFF
--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -800,9 +800,17 @@ void HDText::drawEntryText()
 	const auto old_size = m_text_size;
 	setTextSize(18);
 	const auto level_name = d2::getLevelName(*d2::level_no);
+	const std::set<int> exclusions = { 
+		38,	                       // Tristram
+		109,                       // Harrogath
+		121,                       // Nihlathak's Temple
+		66, 67, 68, 69, 70, 71, 72 // Tal Rasha's Tombs
+	};
 	std::wstring entry_text = L"Entering ";
+
+	// Skip adding "The" if it already exists or doesn't make grammatical sense
 	if (wcsncmp(level_name, L"The ", 4) != 0) {
-		if (*d2::level_no != 38 && *d2::level_no != 109 && *d2::level_no != 121) {
+		if (exclusions.find(*d2::level_no) == exclusions.end()) {
 			entry_text += L"The ";
 		}
 	}


### PR DESCRIPTION
Quick patch/revert combo to satisfy Senpai.

![image](https://github.com/Project-Diablo-2/d2gl/assets/72973313/334c23db-2f09-4296-b49a-2005fdaba768)

![image](https://github.com/Project-Diablo-2/d2gl/assets/72973313/a4b1492c-bd0b-463c-8b41-bf2ce2f421c5)


The earlier D2GL versions always added a "The" to map names that didn't already contain it, which seemed strange for a few maps. I believe it was also removed so as to make sense with non-English use. Considering PD2's English client requirement, it doesn't seem so bad to continue using it.