### PR TITLE
Quick-fix duplicate screenshots with PrtScr key

### DIFF
--- a/d2gl/src/graphic/context.cpp
+++ b/d2gl/src/graphic/context.cpp
@@ -904,6 +904,11 @@ void Context::resetFileTime()
 
 void Context::takeScreenShot()
 {
+	const uint32_t tickCount = GetTickCount();
+
+	if (ssTickCount > tickCount - 1000)
+		return;
+
 	uint8_t* data = new GLubyte[App.viewport.size.x * App.viewport.size.y * 3];
 	memset(data, 0, App.viewport.size.x * App.viewport.size.y * 3);
 
@@ -912,6 +917,8 @@ void Context::takeScreenShot()
 
 	std::string file_name = helpers::saveScreenShot(data, App.viewport.size.x, App.viewport.size.y);
 	delete[] data;
+
+	ssTickCount = tickCount;
 }
 
 void Context::imguiInit()

--- a/d2gl/src/graphic/context.h
+++ b/d2gl/src/graphic/context.h
@@ -211,6 +211,7 @@ public:
 	void toggleVsync();
 	void setFpsLimit(bool active, int max_fps);
 	void takeScreenShot();
+	uint32_t ssTickCount = 0;
 
 	void imguiStartFrame();
 	void imguiRender();


### PR DESCRIPTION
Reintroduce the apparent one second delay between screenshots according to https://github.com/bayaraa/d2gl/issues/148#issuecomment-2026321352 .