### PR TITLE
Enable saving screenshot of tooltips to clipboard

### DIFF
--- a/d2gl/src/app.h
+++ b/d2gl/src/app.h
@@ -169,6 +169,12 @@ struct D2GLApp {
 		Range<int> height = { 140, 100, 200 };
 	} mini_map;
 
+	struct {
+		bool active = false;
+		glm::vec2 pos = { 0, 0 };
+		glm::vec2 size = { 0, 0 };
+	} tooltip;
+
 #ifdef _DEBUG
 	int var[10] = { 0 };
 #endif

--- a/d2gl/src/d2gl.cpp
+++ b/d2gl/src/d2gl.cpp
@@ -96,6 +96,12 @@ __declspec(dllexport) void __cdecl d2glToggleInterface()
 		d2gl::win32::setCursorLock();
 }
 
+__declspec(dllexport) void __cdecl d2glCopyTooltipScreenShot()
+{
+	if (d2gl::App.tooltip.active)
+		d2gl::helpers::copyTooltipScreenShot();
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/d2gl/src/helpers.cpp
+++ b/d2gl/src/helpers.cpp
@@ -432,6 +432,25 @@ std::string saveScreenShot(uint8_t* data, int width, int height)
 	return file_name;
 }
 
+void copyTooltipScreenShot()
+{
+	HDC hScreen = GetDC(App.hwnd);
+	HDC hDC = CreateCompatibleDC(hScreen);
+	HBITMAP hBitmap = CreateCompatibleBitmap(hScreen, App.tooltip.size.x, App.tooltip.size.y);
+	HGDIOBJ old_obj = SelectObject(hDC, hBitmap);
+	BOOL bRet = BitBlt(hDC, 0, 0, App.tooltip.size.x, App.tooltip.size.y, hScreen, App.tooltip.pos.x, App.tooltip.pos.y, SRCCOPY);
+
+	OpenClipboard(NULL);
+	EmptyClipboard();
+	SetClipboardData(CF_BITMAP, hBitmap);
+	CloseClipboard();
+
+	SelectObject(hDC, old_obj);
+	DeleteDC(hDC);
+	ReleaseDC(NULL, hScreen);
+	DeleteObject(hBitmap);
+}
+
 void loadDlls(const std::string& dlls, bool late)
 {
 	trace_log("Loading %s DLLs.", late ? "late" : "early");

--- a/d2gl/src/helpers.h
+++ b/d2gl/src/helpers.h
@@ -72,6 +72,7 @@ BufferData loadFile(const std::string& file_path);
 ImageData loadImage(const std::string& file_path, bool flipped = true);
 void clearImage(ImageData& image);
 std::string saveScreenShot(uint8_t* data, int width, int height);
+void copyTooltipScreenShot();
 
 void loadDlls(const std::string& dlls, bool late = false);
 

--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -286,6 +286,8 @@ bool HDText::drawText(const wchar_t* str, int x, int y, uint32_t color, uint32_t
 
 bool HDText::drawFramedText(const wchar_t* str, int x, int y, uint32_t color, uint32_t centered)
 {
+	App.tooltip.active = false;
+
 	if (!str || !isActive())
 		return false;
 
@@ -383,6 +385,21 @@ bool HDText::drawFramedText(const wchar_t* str, int x, int y, uint32_t color, ui
 	m_object_bg->setColor(m_bg_color, 1);
 	m_object_bg->setExtra(box_size);
 	App.context->pushObject(m_object_bg);
+
+	// Save size and position of tooltip to be used for screenshots
+	App.tooltip.active = true;
+	float scale_x = (float)(App.viewport.stretched.x ? App.window.size.x : App.viewport.size.x) / (float)App.game.size.x;
+	float scale_y = (float)(App.viewport.stretched.y ? App.window.size.y : App.viewport.size.y) / (float)App.game.size.y;
+	App.tooltip.pos.x = (int)(scale_x * pos.x);
+	App.tooltip.pos.y = (int)(scale_y * pos.y);
+	App.tooltip.size.x = (int)(scale_x * box_size.x);
+	App.tooltip.size.y = (int)(scale_y * box_size.y);
+
+	if (!App.viewport.stretched.x)
+		App.tooltip.pos.x += App.viewport.offset.x;
+	if (!App.viewport.stretched.y)
+		App.tooltip.pos.y += App.viewport.offset.y;
+
 
 	pos.y += font_size;
 	font->setShadow(0);


### PR DESCRIPTION
Allow capturing a bitmap of a displayed tooltip and save it to the clipboard.

Occasionally captured frame is misaligned or wrongly sized by up to one pixel per side based on window resolution, viewport offset, and location of tooltip, though in most erroneous cases it's one pixel in each the X and Y axes. If absolutely necessary, I'm sure this is fixable with some math and rounding magic.

Testing key bind removed and function made available via `d2glCopyTooltipScreenShot()`.