### PR TITLE
Block some text behind gold popups

### DIFF
--- a/d2gl/src/d2/common.cpp
+++ b/d2gl/src/d2/common.cpp
@@ -36,6 +36,7 @@ bool* perspective = (bool*)getProc((DLL_D2GFX), (0xE188), (0xE198), (0x10C94), (
 bool* esc_menu_open = (bool*)getProc((DLL_D2CLIENT), (0x1248D8), (0x11A6CC), (0xFB094), (0x1040E4), (0x102B7C), (0xFADA4), (0x11C8B4), (0x3A27E4));
 bool* help_menu_open = (bool*)getProc((DLL_D2CLIENT), (0x1248D8), (0x11A6CC), (0xFB094), (0x1040E4), (0x102B7C), (0xFAE04), (0x11C8B4), (0x3A27E4)); // TODO: only has 1.13c, fix the rest
 bool* is_alt_clicked = (bool*)getProc((DLL_D2CLIENT), (0x1248E8), (0x11A6DC), (0xFB0A4), (0x1040F4), (0x102B8C), (0xFADB4), (0x11C8C4), (0x3A27F4));
+int* gold_trans_popup = (int*)getProc((DLL_D2CLIENT), (0x1248D8), (0x11A6CC), (0xFB094), (0x1040E4), (0x102B7C), (0xFAD74), (0x11C8B4), (0x3A27E4)); // TODO: only has 1.13c, fix the rest
 int is_unit_hovered = 0;
 
 uint32_t* is_in_game = (uint32_t*)getProc((DLL_D2CLIENT), (0x1109FC), (0x1077C4), (0xE48EC), (0xF18C0), (0x11BCC4), (0xF8C9C), (0xF79E0), (0x3A27C0));

--- a/d2gl/src/d2/common.h
+++ b/d2gl/src/d2/common.h
@@ -79,6 +79,7 @@ extern bool* perspective;
 extern bool* help_menu_open;
 extern bool* esc_menu_open;
 extern bool* is_alt_clicked;
+extern int* gold_trans_popup;
 extern int is_unit_hovered;
 
 extern uint32_t* is_in_game;

--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -161,6 +161,10 @@ bool HDText::drawText(const wchar_t* str, int x, int y, uint32_t color, uint32_t
 	if (!isActive() || !str)
 		return false;
 
+	// Hide name and "Gold" behind gold transaction popup in trade window
+	if (*d2::gold_trans_popup && (x > 229 && x < 405) && y == 302)
+		return false;
+
 	auto font = getFont(m_text_size);
 	font->setShadow(1);
 

--- a/d2gl/src/modules/hd_text.cpp
+++ b/d2gl/src/modules/hd_text.cpp
@@ -1054,6 +1054,10 @@ void HDText::drawItemQuantity(bool draw, int x, int y)
 		return;
 	}
 
+	// Hide for items behind gold transaction popup
+	if (*d2::gold_trans_popup && (item_pos.x > 229 && item_pos.x < 405) && (item_pos.y > 161 && item_pos.y < 308))
+		return;
+
 	const auto item = d2::currently_drawing_item;
 	if (item->dwType == d2::UnitType::Item &&
 		d2::getItemLocation(item) != 0xFF &&


### PR DESCRIPTION
Stops item quantities from showing through the deposit/withdraw popup window.
Also stops the same behavior of the second party and "Gold" text in the trade window. This is admittedly a little hacky, but at no real cost unless the text layout is changed in the future.